### PR TITLE
Revert "Fix C++17 issues in HLTrigger/HLTanalyzers"

### DIFF
--- a/HLTanalyzers/src/HLTInfo.cc
+++ b/HLTanalyzers/src/HLTInfo.cc
@@ -217,8 +217,8 @@ void HLTInfo::analyze(const edm::Handle<edm::TriggerResults>                 & h
 	int itrig = index;
  	algoBitToName[itrig] = TString( trigName );
 	
-	TString l1trigName = static_cast<const char *>(algoBitToName[itrig]);
-	std::string l1triggername = static_cast<const char *>(algoBitToName[itrig]);
+	TString l1trigName= std::string (algoBitToName[itrig]); 
+	std::string l1triggername= std::string (algoBitToName[itrig]); 
 
 	HltTree->Branch(l1trigName,l1flag+itrig,l1trigName+"/I");                    
         HltTree->Branch(l1trigName+"_Prescl",l1Prescl+itrig,l1trigName+"_Prescl/I"); 
@@ -238,7 +238,7 @@ void HLTInfo::analyze(const edm::Handle<edm::TriggerResults>                 & h
       if (myflag ) { l1flag[itrig] = 1; }
       else {l1flag[itrig] =0 ; }
 
-      std::string l1triggername = static_cast<const char *>(algoBitToName[itrig]);
+      std::string l1triggername= std::string (algoBitToName[itrig]);
       l1Prescl[itrig] = l1GtUtils.prescaleFactor(iEvent, 
 						 l1triggername, 
 						 iErrorCode);      


### PR DESCRIPTION
This reverts commit 491fd4176988b0f116a90bab6ea5b36250f8c105 which was the "fix c++17 issues" that was targeting only 90X.